### PR TITLE
Cancel drop event to prevent browser navigation

### DIFF
--- a/src/sortable.js
+++ b/src/sortable.js
@@ -120,6 +120,9 @@ function onDrop(event: DragEvent) {
   // Allow dragging task list item, not text, links, or files.
   if (!state) return
 
+  event.preventDefault()
+  event.stopPropagation()
+
   const dropzone = event.currentTarget
   if (!(dropzone instanceof Element)) return
 


### PR DESCRIPTION
Firefox attempts navigation to the domain represented by the task list item text.

Once we've determined the drop event is a task list item dropping onto a task list, cancel any default browser behavior and handle the event locally. If the drop event is for something other than a list item, ignore it and allow the browser or another upstream event listener to handle it.