### PR TITLE
Update event name and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ import '@github/task-lists-element'
 ```js
 const list = document.querySelector('task-lists')
 
-list.addEventListener('task-lists:check', function(event) {
+list.addEventListener('task-lists-check', function(event) {
   const {position, checked} = event.detail
   console.log(position, checked)
 })
 
-list.addEventListener('task-lists:move', function(event) {
+list.addEventListener('task-lists-move', function(event) {
   const {src, dst} = event.detail
   console.log(src, dst)
 })

--- a/examples/index.html
+++ b/examples/index.html
@@ -62,12 +62,12 @@
   <pre class="events"></pre>
   <script type="text/javascript">
     const events = document.querySelector('.events')
-    document.addEventListener('task-lists:check', function(event) {
-      events.append(`task-lists:check - checked: ${event.detail.checked}, position: ${event.detail.position}\n`)
+    document.addEventListener('task-lists-check', function(event) {
+      events.append(`task-lists-check - checked: ${event.detail.checked}, position: ${event.detail.position}\n`)
     })
 
-    document.addEventListener('task-lists:move', function(event) {
-      events.append(`task-lists:move - from: ${event.detail.src}, to: ${event.detail.dst}\n`)
+    document.addEventListener('task-lists-move', function(event) {
+      events.append(`task-lists-move - from: ${event.detail.src}, to: ${event.detail.dst}\n`)
     })
   </script>
 </body>

--- a/src/task-lists-element.js
+++ b/src/task-lists-element.js
@@ -15,6 +15,7 @@ export default class TaskListsElement extends HTMLElement {
 
       this.dispatchEvent(
         new CustomEvent('task-lists-check', {
+          bubbles: true,
           detail: {
             position: position(checkbox),
             checked: checkbox.checked
@@ -207,6 +208,7 @@ function onSorted({src, dst}) {
 
   container.dispatchEvent(
     new CustomEvent('task-lists-move', {
+      bubbles: true,
       detail: {
         src: [lists.indexOf(src.list), src.index],
         dst: [lists.indexOf(dst.list), dst.index]

--- a/src/task-lists-element.js
+++ b/src/task-lists-element.js
@@ -14,8 +14,7 @@ export default class TaskListsElement extends HTMLElement {
       if (!checkbox.classList.contains('task-list-item-checkbox')) return
 
       this.dispatchEvent(
-        new CustomEvent('task-lists:check', {
-          bubbles: true,
+        new CustomEvent('task-lists-check', {
           detail: {
             position: position(checkbox),
             checked: checkbox.checked
@@ -207,8 +206,7 @@ function onSorted({src, dst}) {
   originalLists.delete(container)
 
   container.dispatchEvent(
-    new CustomEvent('task-lists:move', {
-      bubbles: true,
+    new CustomEvent('task-lists-move', {
       detail: {
         src: [lists.indexOf(src.list), src.index],
         dst: [lists.indexOf(dst.list), dst.index]

--- a/test/test.js
+++ b/test/test.js
@@ -69,7 +69,7 @@ describe('task-lists element', function() {
       let called = false
 
       const list = document.querySelector('task-lists')
-      list.addEventListener('task-lists:check', function(event) {
+      list.addEventListener('task-lists-check', function(event) {
         called = true
         const {position, checked} = event.detail
         assert.deepEqual(position, [1, 1])
@@ -87,7 +87,7 @@ describe('task-lists element', function() {
       let called = false
 
       const list = document.querySelector('task-lists')
-      list.addEventListener('task-lists:check', function(event) {
+      list.addEventListener('task-lists-check', function(event) {
         called = true
         const {position, checked} = event.detail
         assert.deepEqual(position, [4, 0])


### PR DESCRIPTION
Ref: https://github.com/github/web-systems/issues/190#issuecomment-472536055

~~It doesn't look like we need these events to bubble 🤔 so I removed it 🤔 .~~

But I'd like to keep the names prefixed, because like https://github.com/github/check-all/pull/2, we are depending on `event.detail` containing the right information, and un-prefixed event names are way more likely to clash with other (bubbling) custom events that from other behaviors. 

Any thoughts, friends?