### PR TITLE
Use octicon as sortable item icon handler icon

### DIFF
--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -82,7 +82,7 @@ export default class TaskListsElement extends HTMLElement {
 const handleTemplate = document.createElement('template')
 handleTemplate.innerHTML = `
   <span class="handle">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+    <svg xmlns="http://www.w3.org/2000/svg" class="drag-handle" aria-hidden="true" viewBox="0 0 16 16" width="16" height="16">
       <path fill-rule="evenodd" d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path>
     </svg>
   </span>`

--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -82,8 +82,8 @@ export default class TaskListsElement extends HTMLElement {
 const handleTemplate = document.createElement('template')
 handleTemplate.innerHTML = `
   <span class="handle">
-    <svg xmlns="http://www.w3.org/2000/svg" class="drag-handle" aria-hidden="true" viewBox="0 0 16 16" width="16" height="16">
-      <path fill-rule="evenodd" d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path>
+    <svg class="drag-handle" aria-hidden="true" width="16" height="16">
+      <path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"/>
     </svg>
   </span>`
 

--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -82,8 +82,8 @@ export default class TaskListsElement extends HTMLElement {
 const handleTemplate = document.createElement('template')
 handleTemplate.innerHTML = `
   <span class="handle">
-    <svg class="drag-handle" aria-hidden="true" width="16" height="15" version="1.1" viewBox="0 0 16 15">
-      <path d="M12,4V5H4V4h8ZM4,8h8V7H4V8Zm0,3h8V10H4v1Z"></path>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+      <path fill-rule="evenodd" d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"></path>
     </svg>
   </span>`
 


### PR DESCRIPTION
This PR is updating the **svg icon** used as handler for a task item to a [Primer icon](https://primer.style/octicons/grabber-16)
This is part of [[Public Beta] Task Lists V2](https://github.com/github/releases/issues/1203)

cc @ohjoycelau for product design decision 

Before 
![image](https://user-images.githubusercontent.com/64602043/107943488-13e86000-6f8d-11eb-911e-ef044c1a0990.png)

After
![image](https://user-images.githubusercontent.com/64602043/107943557-2bbfe400-6f8d-11eb-9125-e249c992386a.png)
