### PR TITLE
Fix ESLint violation

### DIFF
--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -3,10 +3,7 @@ import {SortEndArgs, isDragging, sortable} from './sortable'
 const observers = new WeakMap()
 
 export default class TaskListsElement extends HTMLElement {
-  // eslint-disable-next-line custom-elements/no-constructor
-  constructor() {
-    super()
-
+  connectedCallback(): void {
     this.addEventListener('change', (event: Event) => {
       const checkbox = event.target
       if (!(checkbox instanceof HTMLInputElement)) return
@@ -23,14 +20,10 @@ export default class TaskListsElement extends HTMLElement {
       )
     })
 
-    observers.set(this, new MutationObserver(syncState.bind(null, this)))
-  }
+    const observer = new MutationObserver(syncState.bind(null, this))
+    observers.set(this, observer)
 
-  connectedCallback(): void {
-    const observer = observers.get(this)
-    if (observer) {
-      observer.observe(this, {childList: true, subtree: true})
-    }
+    observer.observe(this, {childList: true, subtree: true})
     syncState(this)
   }
 


### PR DESCRIPTION
Use the `connectedCallback` function instead of a constructor.

>For Custom Elements, the constructor method can be a little unwieldy to use; it is called as soon as the class is instantiated with document.createElement which will be before the element has been appended to the DOM. It can be simpler to put code within the connectedCallback which is fired when the element has been appended into the DOM.

https://github.com/github/eslint-plugin-custom-elements/blob/main/docs/rules/no-constructor.md