### PR TITLE
Use attributes instead of classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,23 @@ With a script tag:
 ```html
 <task-lists sortable>
   <ul class="contains-task-list">
-    <li class="task-list-item">
-      <input type="checkbox" class="task-list-item-checkbox">
+    <li>
+      <input type="checkbox" class="task-list-item-checkbox" />
       Hubot
     </li>
-    <li class="task-list-item">
-      <input type="checkbox" class="task-list-item-checkbox">
+    <li>
+      <input type="checkbox" class="task-list-item-checkbox" />
       Bender
     </li>
   </ul>
 
   <ul class="contains-task-list">
-    <li class="task-list-item">
-      <input type="checkbox" class="task-list-item-checkbox">
+    <li>
+      <input type="checkbox" class="task-list-item-checkbox" />
       BB-8
     </li>
-    <li class="task-list-item">
-      <input type="checkbox" class="task-list-item-checkbox">
+    <li>
+      <input type="checkbox" class="task-list-item-checkbox" />
       WALL-E
     </li>
   </ul>
@@ -57,12 +57,12 @@ With a script tag:
 ```js
 const list = document.querySelector('task-lists')
 
-list.addEventListener('task-lists-check', function(event) {
+list.addEventListener('task-lists-check', function (event) {
   const {position, checked} = event.detail
   console.log(position, checked)
 })
 
-list.addEventListener('task-lists-move', function(event) {
+list.addEventListener('task-lists-move', function (event) {
   const {src, dst} = event.detail
   console.log(src, dst)
 })

--- a/README.md
+++ b/README.md
@@ -30,22 +30,22 @@ With a script tag:
 <task-lists sortable>
   <ul class="contains-task-list">
     <li>
-      <input type="checkbox" class="task-list-item-checkbox" />
+      <input type="checkbox" />
       Hubot
     </li>
     <li>
-      <input type="checkbox" class="task-list-item-checkbox" />
+      <input type="checkbox" />
       Bender
     </li>
   </ul>
 
   <ul class="contains-task-list">
     <li>
-      <input type="checkbox" class="task-list-item-checkbox" />
+      <input type="checkbox" />
       BB-8
     </li>
     <li>
-      <input type="checkbox" class="task-list-item-checkbox" />
+      <input type="checkbox" />
       WALL-E
     </li>
   </ul>

--- a/examples/index.html
+++ b/examples/index.html
@@ -11,13 +11,13 @@
       <ul class="contains-task-list">
         <li>
           <label>
-            <input type="checkbox" class="task-list-item-checkbox" />
+            <input type="checkbox" />
             Hubot
           </label>
         </li>
         <li>
           <label>
-            <input type="checkbox" class="task-list-item-checkbox" />
+            <input type="checkbox" />
             Bender
           </label>
         </li>
@@ -30,20 +30,20 @@
           <ul class="contains-task-list">
             <li>
               <label>
-                <input type="checkbox" class="task-list-item-checkbox" />
+                <input type="checkbox" />
                 WALL-E
               </label>
             </li>
             <li>
               <label>
-                <input type="checkbox" class="task-list-item-checkbox" />
+                <input type="checkbox" />
                 R2-D2
               </label>
 
               <ul class="contains-task-list">
                 <li>
                   <label>
-                    <input type="checkbox" class="task-list-item-checkbox" />
+                    <input type="checkbox" />
                     Baymax
                   </label>
                 </li>
@@ -51,7 +51,7 @@
             </li>
             <li>
               <label>
-                <input type="checkbox" class="task-list-item-checkbox" />
+                <input type="checkbox" />
                 BB-8
               </label>
             </li>

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,13 +9,13 @@
   <body>
     <task-lists sortable>
       <ul class="contains-task-list">
-        <li class="task-list-item">
+        <li>
           <label>
             <input type="checkbox" class="task-list-item-checkbox" />
             Hubot
           </label>
         </li>
-        <li class="task-list-item">
+        <li>
           <label>
             <input type="checkbox" class="task-list-item-checkbox" />
             Bender
@@ -28,20 +28,20 @@
           Nested
 
           <ul class="contains-task-list">
-            <li class="task-list-item">
+            <li>
               <label>
                 <input type="checkbox" class="task-list-item-checkbox" />
                 WALL-E
               </label>
             </li>
-            <li class="task-list-item">
+            <li>
               <label>
                 <input type="checkbox" class="task-list-item-checkbox" />
                 R2-D2
               </label>
 
               <ul class="contains-task-list">
-                <li class="task-list-item">
+                <li>
                   <label>
                     <input type="checkbox" class="task-list-item-checkbox" />
                     Baymax
@@ -49,7 +49,7 @@
                 </li>
               </ul>
             </li>
-            <li class="task-list-item">
+            <li>
               <label>
                 <input type="checkbox" class="task-list-item-checkbox" />
                 BB-8

--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -99,7 +99,7 @@ function initItem(el: HTMLElement) {
   if (!(currentTaskList instanceof TaskListsElement)) return
 
   // Single item task lists are not draggable.
-  if (currentTaskList.querySelectorAll('.task-list-item').length <= 1) return
+  if (currentTaskList.querySelectorAll('li').length <= 1) return
 
   const fragment = handleTemplate.content.cloneNode(true)
   const handle = (fragment as DocumentFragment).querySelector<HTMLElement>('.handle')
@@ -138,7 +138,7 @@ function onListItemMouseOut(event: MouseEvent) {
 function position(checkbox: HTMLInputElement): [number, number] {
   const list = taskList(checkbox)
   if (!list) throw new Error('.contains-task-list not found')
-  const item = checkbox.closest('.task-list-item')
+  const item = checkbox.closest('li')
   const index = item ? Array.from(list.children).indexOf(item) : -1
   return [listIndex(list), index]
 }
@@ -161,7 +161,7 @@ function rootTaskList(node: Element): Element | null {
 }
 
 function syncState(list: TaskListsElement) {
-  const items = list.querySelectorAll<HTMLElement>('.contains-task-list > .task-list-item')
+  const items = list.querySelectorAll<HTMLElement>('.contains-task-list > li')
   for (const el of items) {
     if (isRootTaskList(el)) {
       initItem(el)
@@ -171,7 +171,7 @@ function syncState(list: TaskListsElement) {
 }
 
 function syncDisabled(list: TaskListsElement) {
-  for (const el of list.querySelectorAll('.task-list-item')) {
+  for (const el of list.querySelectorAll('li')) {
     el.classList.toggle('enabled', !list.disabled)
   }
   for (const el of list.querySelectorAll('.task-list-item-checkbox')) {
@@ -222,7 +222,7 @@ function onHandleMouseOver(event: MouseEvent) {
   const target = event.currentTarget
   if (!(target instanceof Element)) return
 
-  const item = target.closest('.task-list-item')
+  const item = target.closest('li')
   if (!item) return
 
   const list = item.closest('task-lists')
@@ -240,7 +240,7 @@ function onHandleMouseOut(event: MouseEvent) {
   const target = event.currentTarget
   if (!(target instanceof Element)) return
 
-  const item = target.closest('.task-list-item')
+  const item = target.closest('li')
   if (!item) return
 
   item.setAttribute('draggable', 'false')

--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -10,7 +10,6 @@ export default class TaskListsElement extends HTMLElement {
     this.addEventListener('change', (event: Event) => {
       const checkbox = event.target
       if (!(checkbox instanceof HTMLInputElement)) return
-      if (!checkbox.classList.contains('task-list-item-checkbox')) return
 
       this.dispatchEvent(
         new CustomEvent('task-lists-check', {
@@ -174,7 +173,7 @@ function syncDisabled(list: TaskListsElement) {
   for (const el of list.querySelectorAll('li')) {
     el.classList.toggle('enabled', !list.disabled)
   }
-  for (const el of list.querySelectorAll('.task-list-item-checkbox')) {
+  for (const el of list.querySelectorAll('li input[type="checkbox"]')) {
     if (el instanceof HTMLInputElement) {
       el.disabled = list.disabled
     }

--- a/test/test.js
+++ b/test/test.js
@@ -19,19 +19,19 @@ describe('task-lists element', function () {
         <task-lists>
           <ul class="contains-task-list">
             <li>
-              <input type="checkbox" class="task-list-item-checkbox"> Hubot
+              <input type="checkbox"> Hubot
             </li>
             <li>
-              <input type="checkbox" class="task-list-item-checkbox"> Bender
+              <input type="checkbox"> Bender
             </li>
           </ul>
 
           <ul class="contains-task-list">
             <li>
-              <input type="checkbox" class="task-list-item-checkbox"> BB-8
+              <input type="checkbox"> BB-8
             </li>
             <li>
-              <input id="wall-e" type="checkbox" class="task-list-item-checkbox"> WALL-E
+              <input id="wall-e" type="checkbox"> WALL-E
             </li>
           </ul>
 
@@ -41,14 +41,14 @@ describe('task-lists element', function () {
               <ul class="contains-task-list">
                 <li>
                   <label>
-                    <input type="checkbox" class="task-list-item-checkbox">
+                    <input type="checkbox">
                     R2-D2
                   </label>
 
                   <ul class="contains-task-list">
                     <li>
                       <label>
-                        <input id="baymax" type="checkbox" class="task-list-item-checkbox">
+                        <input id="baymax" type="checkbox">
                         Baymax
                       </label>
                     </li>

--- a/test/test.js
+++ b/test/test.js
@@ -18,19 +18,19 @@ describe('task-lists element', function () {
       container.innerHTML = `
         <task-lists>
           <ul class="contains-task-list">
-            <li class="task-list-item">
+            <li>
               <input type="checkbox" class="task-list-item-checkbox"> Hubot
             </li>
-            <li class="task-list-item">
+            <li>
               <input type="checkbox" class="task-list-item-checkbox"> Bender
             </li>
           </ul>
 
           <ul class="contains-task-list">
-            <li class="task-list-item">
+            <li>
               <input type="checkbox" class="task-list-item-checkbox"> BB-8
             </li>
-            <li class="task-list-item">
+            <li>
               <input id="wall-e" type="checkbox" class="task-list-item-checkbox"> WALL-E
             </li>
           </ul>
@@ -39,14 +39,14 @@ describe('task-lists element', function () {
             <li>
               Nested
               <ul class="contains-task-list">
-                <li class="task-list-item">
+                <li>
                   <label>
                     <input type="checkbox" class="task-list-item-checkbox">
                     R2-D2
                   </label>
 
                   <ul class="contains-task-list">
-                    <li class="task-list-item">
+                    <li>
                       <label>
                         <input id="baymax" type="checkbox" class="task-list-item-checkbox">
                         Baymax


### PR DESCRIPTION
CSS classes are used for styling elements, and by using classes for querying elements within the Web Component, we conflate behavioral and styling concepts. Instead, we can assume that lists that are children of `<task-lists>` should be initialized as task lists.

Due to the change in required markup, this will be a breaking change.