### PR TITLE
Fix: Compute the task list item index correctly.

### DIFF
--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -132,7 +132,11 @@ function position(checkbox: HTMLInputElement): [number, number] {
   const list = taskList(checkbox)
   if (!list) throw new Error('.contains-task-list not found')
   const item = checkbox.closest('.task-list-item')
-  const index = item ? Array.from(list.children).indexOf(item) : -1
+  const index = item
+    ? Array.from(list.children)
+        .filter(el => el.classList.contains('task-list-item'))
+        .indexOf(item)
+    : -1
   return [listIndex(list), index]
 }
 

--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -132,11 +132,8 @@ function position(checkbox: HTMLInputElement): [number, number] {
   const list = taskList(checkbox)
   if (!list) throw new Error('.contains-task-list not found')
   const item = checkbox.closest('.task-list-item')
-  const index = item
-    ? Array.from(list.children)
-        .filter(el => el.classList.contains('task-list-item'))
-        .indexOf(item)
-    : -1
+  const listItems = Array.from(list.children).filter(el => el.classList.contains('task-list-item'))
+  const index = item ? listItems.indexOf(item) : -1
   return [listIndex(list), index]
 }
 


### PR DESCRIPTION
Fixes #25 

### Problem
If a task list contained elements other than task list items (for example `<a>`) then the position of the checked/unchecke task list item was being calculated incorrectly.

### Fix
The position of a task list item should be computed using only other task list items (and ignoring any other elements).
