### PR TITLE
Change the logic for calculating item position

### DIFF
--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -132,7 +132,7 @@ function position(checkbox: HTMLInputElement): [number, number] {
   const list = taskList(checkbox)
   if (!list) throw new Error('.contains-task-list not found')
   const item = checkbox.closest('.task-list-item')
-  const listItems = Array.from(list.children).filter(el => el.classList.contains('task-list-item'))
+  const listItems = Array.from(list.children).filter(el => el.tagName === 'LI')
   const index = item ? listItems.indexOf(item) : -1
   return [listIndex(list), index]
 }

--- a/test/test.js
+++ b/test/test.js
@@ -57,6 +57,22 @@ describe('task-lists element', function () {
               </ul>
             </li>
           </ol>
+
+          <ul class="contains-task-list">
+            <li class="task-list-item">
+              <label>
+                <input type="checkbox" class="task-list-item-checkbox">
+                R2-D2
+              </label>
+            </li>
+            <li>bam</li>
+            <li class="task-list-item">
+              <label>
+                <input id="c3po" type="checkbox" class="task-list-item-checkbox">
+                C-3PO
+              </label>
+            </li>
+          </ul>
         </task-lists>`
       document.body.append(container)
     })
@@ -95,6 +111,24 @@ describe('task-lists element', function () {
       })
 
       const checkbox = document.querySelector('#baymax')
+      checkbox.checked = true
+      checkbox.dispatchEvent(new CustomEvent('change', {bubbles: true}))
+
+      assert(called)
+    })
+
+    it('emits check event with the right position for mixed task list', function () {
+      let called = false
+
+      const list = document.querySelector('task-lists')
+      list.addEventListener('task-lists-check', function (event) {
+        called = true
+        const {position, checked} = event.detail
+        assert.deepEqual(position, [5, 2])
+        assert(checked)
+      })
+
+      const checkbox = document.querySelector('#c3po')
       checkbox.checked = true
       checkbox.dispatchEvent(new CustomEvent('change', {bubbles: true}))
 


### PR DESCRIPTION
Use tagName === `LI` to calculate item position within a list.

Part of the fix for https://github.com/github/issues/issues/2047

The logic for position calculation was different from the [server code](https://github.com/github/github/blob/master/lib/task_list/check_item.rb#L102).