### PR TITLE
 Make task-lists-elements CSP Trusted Types compatible

### DIFF
--- a/src/task-lists-element.ts
+++ b/src/task-lists-element.ts
@@ -74,12 +74,18 @@ export default class TaskListsElement extends HTMLElement {
 }
 
 const handleTemplate = document.createElement('template')
-handleTemplate.innerHTML = `
-  <span class="handle">
-    <svg class="drag-handle" aria-hidden="true" width="16" height="16">
-      <path d="M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z"/>
-    </svg>
-  </span>`
+const span = handleTemplate.content.appendChild(document.createElement('span'))
+span.classList.add('handle')
+const svg = span.appendChild(document.createElement('svg'))
+svg.classList.add('drag-handle')
+svg.setAttribute('aria-hidden', 'true')
+svg.setAttribute('width', '16')
+svg.setAttribute('height', '16')
+const path = svg.appendChild(document.createElement('path'))
+path.setAttribute(
+  'd',
+  'M10 13a1 1 0 100-2 1 1 0 000 2zm-4 0a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zm3 1a1 1 0 100-2 1 1 0 000 2zm1-5a1 1 0 11-2 0 1 1 0 012 0zM6 5a1 1 0 100-2 1 1 0 000 2z'
+)
 
 const initialized = new WeakMap()
 


### PR DESCRIPTION
This change makes task-lists-elements compatible with the [CSP directive Trusted Types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/trusted-types). This CSP directive allows developers to mark a value as a Trusted Type, usually this would be done in conjunction with running some type of sanitizer like DOMPurify to ensure the value doesn't contain any unsafe elements. Fortunately, task-lists-elements doesn't have major violations, just this one. Unfortunately the change in this PR does not buy any security benefits, it just adheres to the Trusted Types API -- not passing bare strings directly to potentially dangerous injection sinks. Currently this implementation is the best way to make this library compatible with trusted types.