### PR TITLE
Set the version field to `0.0.0-development`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/task-lists-element",
-  "version": "2.0.2",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/task-lists-element",
-  "version": "2.0.2",
+  "version": "0.0.0-development",
   "description": "Drag and drop task list items.",
   "repository": "github/task-lists-element",
   "main": "dist/task-lists-element.js",


### PR DESCRIPTION
The publication workflow will set the version based on the tag of a created GitHub release: https://github.com/github/task-lists-element/blob/70675e8c39a455107870b38e87866e2d6ce6f8b6/.github/workflows/publish.yml